### PR TITLE
fix: keep filename column filling after resize

### DIFF
--- a/cardinal/src/hooks/__tests__/resizeDrag.test.ts
+++ b/cardinal/src/hooks/__tests__/resizeDrag.test.ts
@@ -1,0 +1,75 @@
+import type { MouseEvent as ReactMouseEvent } from 'react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { startColumnResizeDrag } from '../resizeDrag';
+
+const createResizeStartEvent = (
+  element: HTMLSpanElement,
+  clientX: number,
+): ReactMouseEvent<HTMLSpanElement> =>
+  ({
+    clientX,
+    currentTarget: element,
+    preventDefault: vi.fn(),
+    stopPropagation: vi.fn(),
+  }) as unknown as ReactMouseEvent<HTMLSpanElement>;
+
+describe('startColumnResizeDrag', () => {
+  let animationFrameCallback: FrameRequestCallback | null = null;
+
+  beforeEach(() => {
+    animationFrameCallback = null;
+    vi.spyOn(window, 'requestAnimationFrame').mockImplementation((callback) => {
+      animationFrameCallback = callback;
+      return 1;
+    });
+    vi.spyOn(window, 'cancelAnimationFrame').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    document.body.style.cursor = '';
+    document.body.style.userSelect = '';
+    vi.restoreAllMocks();
+  });
+
+  it('coalesces mousemove width updates into one animation frame', () => {
+    const applyWidth = vi.fn();
+    const resizer = document.createElement('span');
+
+    startColumnResizeDrag({
+      event: createResizeStartEvent(resizer, 100),
+      startWidth: 200,
+      clampWidth: (value) => value,
+      applyWidth,
+    });
+
+    document.dispatchEvent(new MouseEvent('mousemove', { clientX: 110 }));
+    document.dispatchEvent(new MouseEvent('mousemove', { clientX: 125 }));
+
+    expect(applyWidth).not.toHaveBeenCalled();
+
+    animationFrameCallback?.(performance.now());
+
+    expect(applyWidth).toHaveBeenCalledTimes(1);
+    expect(applyWidth).toHaveBeenCalledWith(225);
+  });
+
+  it('flushes the latest pending width on mouseup', () => {
+    const applyWidth = vi.fn();
+    const resizer = document.createElement('span');
+
+    startColumnResizeDrag({
+      event: createResizeStartEvent(resizer, 100),
+      startWidth: 200,
+      clampWidth: (value) => value,
+      applyWidth,
+    });
+
+    document.dispatchEvent(new MouseEvent('mousemove', { clientX: 135 }));
+    document.dispatchEvent(new MouseEvent('mouseup'));
+
+    expect(window.cancelAnimationFrame).toHaveBeenCalledWith(1);
+    expect(applyWidth).toHaveBeenCalledTimes(1);
+    expect(applyWidth).toHaveBeenCalledWith(235);
+  });
+});

--- a/cardinal/src/hooks/__tests__/useColumnResize.test.ts
+++ b/cardinal/src/hooks/__tests__/useColumnResize.test.ts
@@ -1,0 +1,226 @@
+import { act, renderHook } from '@testing-library/react';
+import type { MouseEvent as ReactMouseEvent } from 'react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { CONTAINER_PADDING, MIN_COL_WIDTH, SCROLLBAR_WIDTH } from '../../constants';
+import { useColumnResize } from '../useColumnResize';
+
+const mocks = vi.hoisted(() => ({
+  startColumnResizeDrag: vi.fn(),
+}));
+
+vi.mock('../resizeDrag', () => ({
+  startColumnResizeDrag: mocks.startColumnResizeDrag,
+}));
+
+type ResizeDragOptions = {
+  applyWidth: (nextWidth: number) => void;
+};
+
+const setWindowWidth = (width: number) => {
+  Object.defineProperty(window, 'innerWidth', {
+    value: width,
+    writable: true,
+    configurable: true,
+  });
+};
+
+const createResizeStartEvent = (): ReactMouseEvent<HTMLSpanElement> =>
+  ({
+    currentTarget: document.createElement('span'),
+    preventDefault: vi.fn(),
+    stopPropagation: vi.fn(),
+  }) as unknown as ReactMouseEvent<HTMLSpanElement>;
+
+const dispatchWindowResize = () => {
+  act(() => {
+    window.dispatchEvent(new Event('resize'));
+  });
+};
+
+const sumColumnWidths = (widths: ReturnType<typeof useColumnResize>['colWidths']) =>
+  widths.filename + widths.path + widths.size + widths.modified + widths.created;
+
+const fixedColumnWidth = (widths: ReturnType<typeof useColumnResize>['colWidths']) =>
+  widths.path + widths.size + widths.modified + widths.created;
+
+const getLastResizeDragOptions = () => {
+  const calls = mocks.startColumnResizeDrag.mock.calls;
+  return calls[calls.length - 1]?.[0] as ResizeDragOptions;
+};
+
+describe('useColumnResize', () => {
+  beforeEach(() => {
+    mocks.startColumnResizeDrag.mockClear();
+  });
+
+  afterEach(() => {
+    setWindowWidth(1024);
+  });
+
+  it('shrinks the filename column in auto mode when the window shrinks', () => {
+    setWindowWidth(1000);
+    const { result } = renderHook(() => useColumnResize());
+    const initialWidths = result.current.colWidths;
+
+    setWindowWidth(800);
+    dispatchWindowResize();
+
+    const fixedWidth =
+      initialWidths.path + initialWidths.size + initialWidths.modified + initialWidths.created;
+    const availableWidth = window.innerWidth - CONTAINER_PADDING - SCROLLBAR_WIDTH;
+
+    expect(result.current.colWidths).toEqual({
+      ...initialWidths,
+      filename: availableWidth - fixedWidth,
+    });
+  });
+
+  it('expands the filename column to fill remaining space when columns fit the window', () => {
+    setWindowWidth(1000);
+    const { result } = renderHook(() => useColumnResize());
+    const initialWidths = result.current.colWidths;
+
+    setWindowWidth(1200);
+    dispatchWindowResize();
+
+    const fixedWidth =
+      initialWidths.path + initialWidths.size + initialWidths.modified + initialWidths.created;
+    const availableWidth = window.innerWidth - CONTAINER_PADDING - SCROLLBAR_WIDTH;
+
+    expect(result.current.colWidths).toEqual({
+      ...initialWidths,
+      filename: availableWidth - fixedWidth,
+    });
+  });
+
+  it('keeps all column widths independent in manual mode while the window resizes', () => {
+    setWindowWidth(1000);
+    const { result } = renderHook(() => useColumnResize());
+    const initialWidths = result.current.colWidths;
+
+    // Any direct column drag switches the hook into manual mode, where the
+    // user's chosen widths are preserved across unrelated window resizes.
+    act(() => {
+      result.current.onResizeStart('path')(createResizeStartEvent());
+      getLastResizeDragOptions().applyWidth(initialWidths.path + 50);
+    });
+    const manualWidths = result.current.colWidths;
+
+    setWindowWidth(1500);
+    dispatchWindowResize();
+    expect(result.current.colWidths).toEqual(manualWidths);
+
+    setWindowWidth(800);
+    dispatchWindowResize();
+    expect(result.current.colWidths).toEqual(manualWidths);
+  });
+
+  it('switches from manual back to auto when a window resize matches the total column width', () => {
+    setWindowWidth(1000);
+    const { result } = renderHook(() => useColumnResize());
+    const initialWidths = result.current.colWidths;
+
+    act(() => {
+      result.current.onResizeStart('path')(createResizeStartEvent());
+      getLastResizeDragOptions().applyWidth(initialWidths.path + 50);
+    });
+
+    const manualWidths = result.current.colWidths;
+    const manualTotal = sumColumnWidths(manualWidths);
+    // +3px is inside AUTO_SNAP_THRESHOLD, so a window resize should be treated
+    // as returning the manual layout to a fitted, Finder-style auto layout.
+    setWindowWidth(manualTotal + CONTAINER_PADDING + SCROLLBAR_WIDTH + 3);
+    dispatchWindowResize();
+
+    expect(result.current.colWidths.filename).toBe(manualWidths.filename + 3);
+
+    // After snapping back to auto, later window resizes should again be absorbed
+    // by the filename column.
+    setWindowWidth(manualTotal + CONTAINER_PADDING + SCROLLBAR_WIDTH + 100);
+    dispatchWindowResize();
+
+    expect(result.current.colWidths.filename).toBe(manualWidths.filename + 100);
+  });
+
+  it('keeps manual mode when a window resize is outside the snap threshold', () => {
+    setWindowWidth(1000);
+    const { result } = renderHook(() => useColumnResize());
+    const initialWidths = result.current.colWidths;
+
+    act(() => {
+      result.current.onResizeStart('path')(createResizeStartEvent());
+      getLastResizeDragOptions().applyWidth(initialWidths.path + 50);
+    });
+
+    const manualWidths = result.current.colWidths;
+    // +6px is just outside the 5px snap band; this preserves the manual layout
+    // and verifies the boundary is intentional rather than any resize near total.
+    setWindowWidth(sumColumnWidths(manualWidths) + CONTAINER_PADDING + SCROLLBAR_WIDTH + 6);
+    dispatchWindowResize();
+
+    expect(result.current.colWidths).toEqual(manualWidths);
+  });
+
+  it('keeps filename at its minimum width in auto mode when fixed columns overflow', () => {
+    setWindowWidth(1000);
+    const { result } = renderHook(() => useColumnResize());
+    const initialWidths = result.current.colWidths;
+
+    // Once fixed columns alone exceed available width, filename cannot absorb
+    // any more shrinkage and should clamp at MIN_COL_WIDTH.
+    setWindowWidth(fixedColumnWidth(initialWidths) + CONTAINER_PADDING + SCROLLBAR_WIDTH - 20);
+    dispatchWindowResize();
+
+    expect(result.current.colWidths).toEqual({
+      ...initialWidths,
+      filename: MIN_COL_WIDTH,
+    });
+  });
+
+  it('switches to manual mode when the filename column is resized directly', () => {
+    setWindowWidth(1000);
+    const { result } = renderHook(() => useColumnResize());
+    const initialWidths = result.current.colWidths;
+
+    act(() => {
+      result.current.onResizeStart('filename')(createResizeStartEvent());
+      getLastResizeDragOptions().applyWidth(initialWidths.filename + 50);
+    });
+    const manualWidths = result.current.colWidths;
+
+    setWindowWidth(1200);
+    dispatchWindowResize();
+
+    expect(result.current.colWidths).toEqual(manualWidths);
+  });
+
+  it('uses autoFitColumns to return to auto mode after manual resizing', () => {
+    setWindowWidth(1000);
+    const { result } = renderHook(() => useColumnResize());
+    const initialWidths = result.current.colWidths;
+
+    act(() => {
+      result.current.onResizeStart('path')(createResizeStartEvent());
+      getLastResizeDragOptions().applyWidth(initialWidths.path + 50);
+    });
+
+    setWindowWidth(1200);
+    act(() => {
+      // Header context-menu auto-fit is an explicit user action to return from
+      // manual widths to the default auto filename layout.
+      result.current.autoFitColumns();
+    });
+    const autoFitWidths = result.current.colWidths;
+
+    setWindowWidth(1300);
+    dispatchWindowResize();
+
+    const fixedWidth = fixedColumnWidth(autoFitWidths);
+    const availableWidth = window.innerWidth - CONTAINER_PADDING - SCROLLBAR_WIDTH;
+    expect(result.current.colWidths).toEqual({
+      ...autoFitWidths,
+      filename: availableWidth - fixedWidth,
+    });
+  });
+});

--- a/cardinal/src/hooks/resizeDrag.ts
+++ b/cardinal/src/hooks/resizeDrag.ts
@@ -18,16 +18,43 @@ export const startColumnResizeDrag = ({
 
   const resizerElement = event.currentTarget;
   const startX = event.clientX;
+  let animationFrameId: number | null = null;
+  let pendingWidth: number | null = null;
   resizerElement.classList.add('col-resizer--dragging');
+
+  const flushPendingWidth = () => {
+    animationFrameId = null;
+    if (pendingWidth === null) {
+      return;
+    }
+    const nextWidth = pendingWidth;
+    pendingWidth = null;
+    applyWidth(nextWidth);
+  };
+
+  const scheduleWidthUpdate = (nextWidth: number) => {
+    pendingWidth = nextWidth;
+
+    if (animationFrameId !== null) {
+      return;
+    }
+
+    animationFrameId = window.requestAnimationFrame(flushPendingWidth);
+  };
 
   const handleMouseMove = (moveEvent: MouseEvent) => {
     moveEvent.preventDefault();
     document.body.style.cursor = 'col-resize';
     const delta = moveEvent.clientX - startX;
-    applyWidth(clampWidth(startWidth + delta));
+    scheduleWidthUpdate(clampWidth(startWidth + delta));
   };
 
   const handleMouseUp = () => {
+    if (animationFrameId !== null) {
+      window.cancelAnimationFrame(animationFrameId);
+      animationFrameId = null;
+    }
+    flushPendingWidth();
     document.removeEventListener('mousemove', handleMouseMove);
     document.removeEventListener('mouseup', handleMouseUp);
     document.body.style.userSelect = '';

--- a/cardinal/src/hooks/useColumnResize.ts
+++ b/cardinal/src/hooks/useColumnResize.ts
@@ -59,6 +59,45 @@ const calculateAutoColumnWidths = (windowWidth: number): ColumnWidths => {
   return withAutoFilenameWidth(widths, getAvailableWidth(windowWidth));
 };
 
+const resizeForWindowWidth = (prev: ColumnResizeState, available: number): ColumnResizeState => {
+  // Manual mode means the user owns every column width. A window resize should
+  // not disturb those widths unless the viewport is resized back near the
+  // current total, which is our snap point for returning to autoFilename mode.
+  if (
+    prev.mode === 'manual' &&
+    Math.abs(available - getTotalWidth(prev.widths)) > AUTO_SNAP_THRESHOLD
+  ) {
+    return prev;
+  }
+
+  const widths = withAutoFilenameWidth(prev.widths, available);
+  // Avoid rerendering on resize events that do not actually change either the
+  // layout mode or the derived filename width.
+  if (prev.mode === 'autoFilename' && widths === prev.widths) {
+    return prev;
+  }
+
+  return { mode: 'autoFilename', widths };
+};
+
+const resizeColumnManually = (
+  prev: ColumnResizeState,
+  key: ColumnKey,
+  newWidth: number,
+): ColumnResizeState => {
+  // Dragging any column is a user override, so even a no-op width update should
+  // leave autoFilename mode and enter manual mode. Once already manual, preserve
+  // the previous state object when the width is unchanged; resizeDrag can emit
+  // repeated values during rAF coalescing, and returning prev avoids redundant
+  // React work.
+  const widths = prev.widths[key] === newWidth ? prev.widths : { ...prev.widths, [key]: newWidth };
+  if (prev.mode === 'manual' && widths === prev.widths) {
+    return prev;
+  }
+
+  return { mode: 'manual', widths };
+};
+
 export function useColumnResize() {
   const [state, setState] = useState<ColumnResizeState>(() => ({
     mode: 'autoFilename',
@@ -73,20 +112,7 @@ export function useColumnResize() {
     const handleResize = () => {
       setState((prev) => {
         const available = getAvailableWidth(window.innerWidth);
-
-        if (
-          prev.mode === 'manual' &&
-          Math.abs(available - getTotalWidth(prev.widths)) > AUTO_SNAP_THRESHOLD
-        ) {
-          return prev;
-        }
-
-        const widths = withAutoFilenameWidth(prev.widths, available);
-        if (prev.mode === 'autoFilename' && widths === prev.widths) {
-          return prev;
-        }
-
-        return { mode: 'autoFilename', widths };
+        return resizeForWindowWidth(prev, available);
       });
     };
     window.addEventListener('resize', handleResize);
@@ -106,15 +132,7 @@ export function useColumnResize() {
         startWidth,
         clampWidth,
         applyWidth: (newWidth) => {
-          setState((prev) => {
-            const widths =
-              prev.widths[key] === newWidth ? prev.widths : { ...prev.widths, [key]: newWidth };
-            if (prev.mode === 'manual' && widths === prev.widths) {
-              return prev;
-            }
-
-            return { mode: 'manual', widths };
-          });
+          setState((prev) => resizeColumnManually(prev, key, newWidth));
         },
       });
     },

--- a/cardinal/src/hooks/useColumnResize.ts
+++ b/cardinal/src/hooks/useColumnResize.ts
@@ -1,6 +1,12 @@
-import { useState, useCallback } from 'react';
+import { useState, useCallback, useEffect } from 'react';
 import type { MouseEvent as ReactMouseEvent } from 'react';
-import { calculateInitialColWidths, MAX_COL_WIDTH, MIN_COL_WIDTH } from '../constants';
+import {
+  calculateInitialColWidths,
+  MAX_COL_WIDTH,
+  MIN_COL_WIDTH,
+  CONTAINER_PADDING,
+  SCROLLBAR_WIDTH,
+} from '../constants';
 import type { ColumnKey } from '../constants';
 import { startColumnResizeDrag } from './resizeDrag';
 
@@ -11,6 +17,21 @@ export function useColumnResize() {
     const windowWidth = window.innerWidth;
     return calculateInitialColWidths(windowWidth);
   });
+
+  // Keep the filename column filling whatever horizontal space remains after the
+  // fixed columns and the scrollbar gutter.
+  useEffect(() => {
+    const handleResize = () => {
+      setColWidths((prev) => {
+        const fixedWidth = prev.path + prev.size + prev.modified + prev.created;
+        const available = window.innerWidth - CONTAINER_PADDING - SCROLLBAR_WIDTH;
+        const filename = Math.max(MIN_COL_WIDTH, available - fixedWidth);
+        return { ...prev, filename };
+      });
+    };
+    window.addEventListener('resize', handleResize);
+    return () => window.removeEventListener('resize', handleResize);
+  }, []);
 
   const clampWidth = useCallback(
     (value: number) => Math.max(MIN_COL_WIDTH, Math.min(MAX_COL_WIDTH, value)),

--- a/cardinal/src/hooks/useColumnResize.ts
+++ b/cardinal/src/hooks/useColumnResize.ts
@@ -12,21 +12,81 @@ import { startColumnResizeDrag } from './resizeDrag';
 
 type ColumnWidths = Record<ColumnKey, number>;
 
-export function useColumnResize() {
-  const [colWidths, setColWidths] = useState<ColumnWidths>(() => {
-    const windowWidth = window.innerWidth;
-    return calculateInitialColWidths(windowWidth);
-  });
+// Column layout has two intentionally different modes:
+//
+// - autoFilename:
+//   Finder-style layout. The non-filename columns keep their current widths, and
+//   filename is derived from the remaining viewport width:
+//     filename = max(MIN_COL_WIDTH, availableWidth - fixedColumnsWidth)
+//   This keeps the full table aligned to the window while the filename column
+//   absorbs horizontal window resizes. If the fixed columns alone cannot fit,
+//   filename stops at MIN_COL_WIDTH and horizontal overflow is expected.
+//
+// - manual:
+//   User-controlled layout. Dragging any column switches to this mode, and every
+//   column width becomes independent. The total column width may be smaller than,
+//   equal to, or larger than the viewport. Window resizes do not change the
+//   user's chosen widths unless the window is resized back near the current
+//   total column width, which is treated as an intentional return to the
+//   Finder-style fitted layout.
+type ColumnLayoutMode = 'autoFilename' | 'manual';
 
-  // Keep the filename column filling whatever horizontal space remains after the
-  // fixed columns and the scrollbar gutter.
+type ColumnResizeState = {
+  mode: ColumnLayoutMode;
+  widths: ColumnWidths;
+};
+
+// Window resize events and CSS/grid math do not always land on exact integer
+// equality, so use a small snap band when deciding that a manual layout has been
+// resized back to "fits the viewport" and can return to autoFilename mode.
+const AUTO_SNAP_THRESHOLD = 5;
+
+const getAvailableWidth = (windowWidth: number) =>
+  windowWidth - CONTAINER_PADDING - SCROLLBAR_WIDTH;
+
+const getFixedWidth = (widths: ColumnWidths) =>
+  widths.path + widths.size + widths.modified + widths.created;
+
+const getTotalWidth = (widths: ColumnWidths) => getFixedWidth(widths) + widths.filename;
+
+const withAutoFilenameWidth = (widths: ColumnWidths, available: number): ColumnWidths => {
+  const filename = Math.max(MIN_COL_WIDTH, available - getFixedWidth(widths));
+  return widths.filename === filename ? widths : { ...widths, filename };
+};
+
+const calculateAutoColumnWidths = (windowWidth: number): ColumnWidths => {
+  const widths = calculateInitialColWidths(windowWidth);
+  return withAutoFilenameWidth(widths, getAvailableWidth(windowWidth));
+};
+
+export function useColumnResize() {
+  const [state, setState] = useState<ColumnResizeState>(() => ({
+    mode: 'autoFilename',
+    widths: calculateAutoColumnWidths(window.innerWidth),
+  }));
+
+  // In autoFilename mode, every window resize re-derives filename from the
+  // current fixed columns. In manual mode, preserve the user's independent
+  // column widths until the viewport width is within AUTO_SNAP_THRESHOLD of the
+  // current column total, then switch back to autoFilename.
   useEffect(() => {
     const handleResize = () => {
-      setColWidths((prev) => {
-        const fixedWidth = prev.path + prev.size + prev.modified + prev.created;
-        const available = window.innerWidth - CONTAINER_PADDING - SCROLLBAR_WIDTH;
-        const filename = Math.max(MIN_COL_WIDTH, available - fixedWidth);
-        return { ...prev, filename };
+      setState((prev) => {
+        const available = getAvailableWidth(window.innerWidth);
+
+        if (
+          prev.mode === 'manual' &&
+          Math.abs(available - getTotalWidth(prev.widths)) > AUTO_SNAP_THRESHOLD
+        ) {
+          return prev;
+        }
+
+        const widths = withAutoFilenameWidth(prev.widths, available);
+        if (prev.mode === 'autoFilename' && widths === prev.widths) {
+          return prev;
+        }
+
+        return { mode: 'autoFilename', widths };
       });
     };
     window.addEventListener('resize', handleResize);
@@ -40,27 +100,36 @@ export function useColumnResize() {
 
   const onResizeStart = useCallback(
     (key: ColumnKey) => (e: ReactMouseEvent<HTMLSpanElement>) => {
-      const startWidth = colWidths[key];
+      const startWidth = state.widths[key];
       startColumnResizeDrag({
         event: e,
         startWidth,
         clampWidth,
         applyWidth: (newWidth) => {
-          setColWidths((prev) => ({ ...prev, [key]: newWidth }));
+          setState((prev) => {
+            const widths =
+              prev.widths[key] === newWidth ? prev.widths : { ...prev.widths, [key]: newWidth };
+            if (prev.mode === 'manual' && widths === prev.widths) {
+              return prev;
+            }
+
+            return { mode: 'manual', widths };
+          });
         },
       });
     },
-    [clampWidth, colWidths],
+    [clampWidth, state.widths],
   );
 
   const autoFitColumns = useCallback(() => {
-    const windowWidth = window.innerWidth;
-    const newColWidths = calculateInitialColWidths(windowWidth);
-    setColWidths(newColWidths);
+    setState({
+      mode: 'autoFilename',
+      widths: calculateAutoColumnWidths(window.innerWidth),
+    });
   }, []);
 
   return {
-    colWidths,
+    colWidths: state.widths,
     onResizeStart,
     autoFitColumns,
   };


### PR DESCRIPTION
the columns' widths stay fixed after horizontal resize. 

i referred to Finder's design and make the filename, which is the first column, fill whatever horizontal space remains.
