### PR TITLE
feat: better command line interaction

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -152,6 +152,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
+name = "cfg_aliases"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
+
+[[package]]
 name = "chrono"
 version = "0.4.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -172,6 +178,17 @@ checksum = "b193af5b67834b676abd72466a96c1024e6a6ad978a1f484bd90b85c94041351"
 dependencies = [
  "clap_builder",
  "clap_derive",
+]
+
+[[package]]
+name = "clap-verbosity-flag"
+version = "3.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d92b1fab272fe943881b77cc6e920d6543e5b1bfadbd5ed81c7c5a755742394"
+dependencies = [
+ "clap",
+ "log",
+ "tracing-core",
 ]
 
 [[package]]
@@ -203,6 +220,15 @@ name = "clap_lex"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
+
+[[package]]
+name = "clipboard-win"
+version = "5.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bde03770d3df201d4fb868f2c9c59e66a3e4e2bd06692a0fe701e7103c7e84d4"
+dependencies = [
+ "error-code",
+]
 
 [[package]]
 name = "cobs"
@@ -321,6 +347,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "edd0f118536f44f5ccd48bcb8b111bdc3de888b58c74639dfb034a357d0f206d"
 
 [[package]]
+name = "endian-type"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "869b0adbda23651a9c5c0c3d270aac9fcb52e8622a8f2b17e57802d7791962f2"
+
+[[package]]
 name = "enumn"
 version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -346,6 +378,12 @@ dependencies = [
  "libc",
  "windows-sys",
 ]
+
+[[package]]
+name = "error-code"
+version = "3.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dea2df4cf52843e0452895c455a1a2cfbb842a1e7329671acf418fdc53ed4c59"
 
 [[package]]
 name = "fastrand"
@@ -464,6 +502,15 @@ name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "home"
+version = "0.5.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc627f471c528ff0c4a49e1d5e60450c8f6461dd6d10ba9dcd3a61d3dff7728d"
+dependencies = [
+ "windows-sys",
+]
 
 [[package]]
 name = "iana-time-zone"
@@ -635,10 +682,12 @@ dependencies = [
  "anyhow",
  "cardinal-sdk",
  "clap",
+ "clap-verbosity-flag",
  "crossbeam-channel",
  "fswalk",
  "namepool",
  "query-segmentation",
+ "rustyline",
  "search-cache",
  "search-cancel",
  "serde",
@@ -680,6 +729,27 @@ dependencies = [
  "rustc-hash",
  "search-cancel",
  "serde",
+]
+
+[[package]]
+name = "nibble_vec"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77a5d83df9f36fe23f0c3648c6bbb8b0298bb5f1939c8f2704431371f4b84d43"
+dependencies = [
+ "smallvec",
+]
+
+[[package]]
+name = "nix"
+version = "0.31.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d6d0705320c1e6ba1d912b5e37cf18071b6c2e9b7fa8215a1e8a7651966f5d3"
+dependencies = [
+ "bitflags",
+ "cfg-if",
+ "cfg_aliases",
+ "libc",
 ]
 
 [[package]]
@@ -1065,6 +1135,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
+name = "radix_trie"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b4431027dcd37fc2a73ef740b5f233aa805897935b8bce0195e41bbf9a3289a"
+dependencies = [
+ "endian-type",
+ "nibble_vec",
+]
+
+[[package]]
 name = "rand"
 version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1192,6 +1272,27 @@ name = "rustversion"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
+
+[[package]]
+name = "rustyline"
+version = "18.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4a990b25f351b25139ddc7f21ee3f6f56f86d6846b74ac8fad3a719a287cd4a0"
+dependencies = [
+ "bitflags",
+ "cfg-if",
+ "clipboard-win",
+ "home",
+ "libc",
+ "log",
+ "memchr",
+ "nix",
+ "radix_trie",
+ "unicode-segmentation",
+ "unicode-width",
+ "utf8parse",
+ "windows-sys",
+]
 
 [[package]]
 name = "scopeguard"
@@ -1557,6 +1658,18 @@ checksum = "5fd4f6878c9cb28d874b009da9e8d183b5abc80117c40bbd187a1fde336be6e8"
 dependencies = [
  "tinyvec",
 ]
+
+[[package]]
+name = "unicode-segmentation"
+version = "1.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9629274872b2bfaf8d66f5f15725007f635594914870f65218920345aa11aa8c"
+
+[[package]]
+name = "unicode-width"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254"
 
 [[package]]
 name = "unicode-xid"

--- a/lsf/Cargo.toml
+++ b/lsf/Cargo.toml
@@ -15,3 +15,5 @@ clap = { version = "4", features = ["derive"] }
 anyhow = "1.0.97"
 crossbeam-channel = "0.5.15"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
+clap-verbosity-flag = {version = "3.0.4", features = ["tracing"]}
+rustyline = "18.0.0"

--- a/lsf/Cargo.toml
+++ b/lsf/Cargo.toml
@@ -15,5 +15,5 @@ clap = { version = "4", features = ["derive"] }
 anyhow = "1.0.97"
 crossbeam-channel = "0.5.15"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
-clap-verbosity-flag = {version = "3.0.4", features = ["tracing"]}
+clap-verbosity-flag = { version = "3.0.4", features = ["tracing"] }
 rustyline = "18.0.0"

--- a/lsf/src/cli.rs
+++ b/lsf/src/cli.rs
@@ -8,4 +8,6 @@ pub struct Cli {
     pub refresh: bool,
     #[clap(long, default_value = "/")]
     pub path: PathBuf,
+    #[command(flatten)]
+    pub verbosity: clap_verbosity_flag::Verbosity,
 }

--- a/lsf/src/main.rs
+++ b/lsf/src/main.rs
@@ -5,28 +5,29 @@ use cardinal_sdk::EventWatcher;
 use clap::Parser;
 use cli::Cli;
 use crossbeam_channel::{Sender, bounded, unbounded};
+use rustyline::{DefaultEditor, error::ReadlineError};
 use search_cache::{HandleFSEError, SearchCache, SearchResultNode};
 use search_cancel::CancellationToken;
 use std::{
-    io::Write,
     path::{Path, PathBuf},
     sync::atomic::AtomicBool,
 };
-use tracing_subscriber::{EnvFilter, filter::LevelFilter};
+use tracing_subscriber::EnvFilter;
 
 const CACHE_PATH: &str = "target/cache.zstd";
 const IGNORE_PATH: &str = "/System/Volumes/Data"; // macOS specific ignore path
 static NEVER_STOPPED: AtomicBool = AtomicBool::new(false);
 
 fn main() -> Result<()> {
+    let cli = Cli::parse();
+
     let builder = tracing_subscriber::fmt();
     if let Ok(filter) = EnvFilter::try_from_default_env() {
         builder.with_env_filter(filter).init();
     } else {
-        builder.with_max_level(LevelFilter::INFO).init();
+        builder.with_max_level(cli.verbosity.tracing_level()).init();
     }
 
-    let cli = Cli::parse();
     let path = cli.path;
     let ignore_paths = vec![PathBuf::from(IGNORE_PATH)];
     let mut cache = if cli.refresh {
@@ -105,34 +106,48 @@ fn main() -> Result<()> {
         println!("fsevent processing is done");
     });
 
-    let stdin = std::io::stdin();
-    let mut stdout = std::io::stdout();
+    let mut rl = DefaultEditor::new().expect("Failed to create rustyline editor");
     loop {
-        print!("> ");
-        stdout.flush().unwrap();
-        let mut line = String::new();
-        stdin.read_line(&mut line).unwrap();
-        let line = line.trim();
-        if line.is_empty() {
-            continue;
-        } else if line == "/bye" {
-            break;
-        }
+        let readline = rl.readline("> ");
+        match readline {
+            Ok(line) => {
+                let line = line.trim();
+                if line.is_empty() {
+                    continue;
+                } else if line == "/bye" {
+                    break;
+                }
 
-        search_tx
-            .send(line.to_string())
-            .context("search_tx is closed")?;
-        let search_result = search_result_rx
-            .recv()
-            .context("search_result_rx is closed")?;
-        match search_result {
-            Ok(path_set) => {
-                for (i, path) in path_set.into_iter().enumerate() {
-                    println!("[{i}] {:?} {:?}", path.path, path.metadata);
+                let _ = rl.add_history_entry(line);
+
+                search_tx
+                    .send(line.to_string())
+                    .context("search_tx is closed")?;
+                let search_result = search_result_rx
+                    .recv()
+                    .context("search_result_rx is closed")?;
+                match search_result {
+                    Ok(path_set) => {
+                        for (i, path) in path_set.into_iter().enumerate() {
+                            println!("[{i}] {:?} {:?}", path.path, path.metadata);
+                        }
+                    }
+                    Err(e) => {
+                        eprintln!("Failed to search: {e:?}");
+                    }
                 }
             }
-            Err(e) => {
-                eprintln!("Failed to search: {e:?}");
+            Err(ReadlineError::Interrupted) => {
+                eprintln!("Interrupted (Ctrl-C)");
+                break;
+            }
+            Err(ReadlineError::Eof) => {
+                eprintln!("EOF (Ctrl-D)");
+                break;
+            }
+            Err(err) => {
+                eprintln!("Error: {:?}", err);
+                break;
             }
         }
     }


### PR DESCRIPTION
## background 

I wish to use cardinal in terminal. luckily, it has a cli tool `lsf`, but the interaction has some noise. 

## improvements

1. use rustyline for cmd interaction since it supports ctrl-c and other interrupts. otherwise, the cache file won't be saved because of the force-quit. 
2. add verbosity flag for the Cli arguments, which disable the log and provide a cleaner output by default.

## TODOs

- [ ] doc