### PR TITLE
fix: use oneshot channel to send search outcome back

### DIFF
--- a/cardinal/src-tauri/src/background.rs
+++ b/cardinal/src-tauri/src/background.rs
@@ -12,8 +12,7 @@ use once_cell::sync::Lazy;
 use parking_lot::Mutex;
 use rayon::spawn;
 use search_cache::{
-    HandleFSEError, SearchCache, SearchOptions, SearchOutcome, SearchResultNode, SlabIndex,
-    WalkData,
+    HandleFSEError, SearchCache, SearchOptions, SearchResultNode, SlabIndex, WalkData,
 };
 use search_cancel::CancellationToken;
 use serde::Serialize;
@@ -44,7 +43,6 @@ pub struct BackgroundLoopChannels {
     pub finish_rx: Receiver<Sender<Option<SearchCache>>>,
     pub update_window_state_rx: Receiver<()>,
     pub search_rx: Receiver<SearchJob>,
-    pub result_tx: Sender<Result<SearchOutcome>>,
     pub node_info_rx: Receiver<NodeInfoRequest>,
     pub icon_viewport_rx: Receiver<(u64, Vec<SlabIndex>)>,
     pub rescan_rx: Receiver<CancellationToken>,
@@ -309,7 +307,6 @@ pub fn run_background_event_loop(
         finish_rx,
         update_window_state_rx,
         search_rx,
-        result_tx,
         node_info_rx,
         icon_viewport_rx,
         rescan_rx,
@@ -355,6 +352,7 @@ pub fn run_background_event_loop(
                     query,
                     options,
                     cancellation_token,
+                    result_tx
                 } = job.expect("Search channel closed");
                 let opts = SearchOptions::from(options);
                 let payload = cache.search_with_options(&query, opts, cancellation_token);

--- a/cardinal/src-tauri/src/commands.rs
+++ b/cardinal/src-tauri/src/commands.rs
@@ -11,7 +11,7 @@ use crate::{
 use anyhow::{Result, anyhow};
 use base64::{Engine as _, engine::general_purpose};
 use camino::{Utf8Path as Path, Utf8PathBuf as PathBuf};
-use crossbeam_channel::{Receiver, Sender, bounded};
+use crossbeam_channel::{Sender, bounded};
 use objc2::{
     rc::{Retained, autoreleasepool},
     runtime::ProtocolObject,
@@ -51,6 +51,7 @@ pub struct SearchJob {
     pub query: String,
     pub options: SearchOptionsPayload,
     pub cancellation_token: CancellationToken,
+    pub result_tx: Sender<Result<SearchOutcome>>,
 }
 
 #[derive(Debug, Clone)]
@@ -67,10 +68,7 @@ struct SortedViewCache {
 
 pub struct SearchState {
     search_tx: Sender<SearchJob>,
-    result_rx: Receiver<Result<SearchOutcome>>,
-
     node_info_tx: Sender<NodeInfoRequest>,
-
     icon_viewport_tx: Sender<(u64, Vec<SlabIndex>)>,
     rescan_tx: Sender<CancellationToken>,
     watch_config_tx: Sender<WatchConfigUpdate>,
@@ -81,7 +79,6 @@ pub struct SearchState {
 impl SearchState {
     pub fn new(
         search_tx: Sender<SearchJob>,
-        result_rx: Receiver<Result<SearchOutcome>>,
         node_info_tx: Sender<NodeInfoRequest>,
         icon_viewport_tx: Sender<(u64, Vec<SlabIndex>)>,
         rescan_tx: Sender<CancellationToken>,
@@ -90,7 +87,6 @@ impl SearchState {
     ) -> Self {
         Self {
             search_tx,
-            result_rx,
             node_info_tx,
             icon_viewport_tx,
             rescan_tx,
@@ -275,16 +271,18 @@ pub async fn search(
 
     let options = options.unwrap_or_default();
     let cancellation_token = CancellationToken::new(version);
+    let (result_tx, result_rx) = bounded(1);
     if let Err(e) = state.search_tx.send(SearchJob {
         query,
         options,
         cancellation_token,
+        result_tx,
     }) {
         error!("Failed to send search request: {e:?}");
         return Ok(SearchResponse::default());
     }
 
-    match state.result_rx.recv() {
+    match result_rx.recv() {
         Ok(res) => res,
         Err(e) => {
             error!("Failed to receive search result: {e:?}");

--- a/cardinal/src-tauri/src/lib.rs
+++ b/cardinal/src-tauri/src/lib.rs
@@ -24,7 +24,7 @@ use lifecycle::{
     APP_QUIT, AppLifecycleState, EXIT_REQUESTED, emit_app_state, load_app_state, update_app_state,
 };
 use once_cell::sync::OnceCell;
-use search_cache::{SearchCache, SearchOutcome, SlabIndex};
+use search_cache::{SearchCache, SlabIndex};
 use search_cancel::CancellationToken;
 use std::{
     path::{Path, PathBuf},
@@ -58,7 +58,6 @@ pub fn run() -> Result<()> {
 
     let (finish_tx, finish_rx) = bounded::<Sender<Option<SearchCache>>>(1);
     let (search_tx, search_rx) = unbounded::<SearchJob>();
-    let (result_tx, result_rx) = unbounded::<Result<SearchOutcome>>();
     let (node_info_tx, node_info_rx) = unbounded::<NodeInfoRequest>();
     let (icon_viewport_tx, icon_viewport_rx) = unbounded::<(u64, Vec<SlabIndex>)>();
     let (rescan_tx, rescan_rx) = unbounded::<CancellationToken>();
@@ -115,7 +114,6 @@ pub fn run() -> Result<()> {
     let app = builder
         .manage(SearchState::new(
             search_tx,
-            result_rx,
             node_info_tx,
             icon_viewport_tx.clone(),
             rescan_tx.clone(),
@@ -153,7 +151,6 @@ pub fn run() -> Result<()> {
     let channels = BackgroundLoopChannels {
         finish_rx,
         search_rx,
-        result_tx,
         node_info_rx,
         icon_viewport_rx,
         rescan_rx,

--- a/doc/inner/background-event-loop.md
+++ b/doc/inner/background-event-loop.md
@@ -9,15 +9,13 @@
 
 ## Channels
 ```text
-search_rx             SearchJob { query, options, cancellation_token, result_tx }
+search_rx             query + SearchOptionsPayload + CancellationToken + result_tx
                       result_tx returns SearchOutcome back to the command handler
 
-node_info_rx          NodeInfoRequest { slab_indices, response_tx }
-                      response_tx returns SearchResultNode expansion
-
+node_info_rx          slab indices -> SearchResultNode expansion
 icon_viewport_rx      visible slab indices for thumbnail prefetch
 icon_update_tx        IconPayload batches back to the UI
-```
+
 rescan_rx             manual full-rescan requests
 watch_config_rx       watch-root / ignore-path changes
 update_window_state_rx

--- a/doc/inner/background-event-loop.md
+++ b/doc/inner/background-event-loop.md
@@ -9,13 +9,15 @@
 
 ## Channels
 ```text
-search_rx             query + SearchOptionsPayload + CancellationToken
-result_tx             SearchOutcome back to the command handler
+search_rx             SearchJob { query, options, cancellation_token, result_tx }
+                      result_tx returns SearchOutcome back to the command handler
 
-node_info_rx          slab indices -> SearchResultNode expansion
+node_info_rx          NodeInfoRequest { slab_indices, response_tx }
+                      response_tx returns SearchResultNode expansion
+
 icon_viewport_rx      visible slab indices for thumbnail prefetch
 icon_update_tx        IconPayload batches back to the UI
-
+```
 rescan_rx             manual full-rescan requests
 watch_config_rx       watch-root / ignore-path changes
 update_window_state_rx


### PR DESCRIPTION
## Goal 

eliminate usage of MPMC channel for search job to make the [http api ](https://github.com/cardisoft/cardinal/pull/184) works with UI.

## Background

http api and UI both interact with the background loop since it's the background loop that receives the search job and do the actual search.
but current usage of MPMC channel may cause race condition, resulting in non-deterministic behavior.

## Solution

add a `Sender` in `SearchJob`(this behavior aligns with `NodeInfoRequest`) so the background loop could send the result back via it.

## Tests

https://gist.github.com/hsqStephenZhang/bd14bd8021be3b49c33afb2194a97711 this test case test the race condition via simulating two concurrrent searches.
it failed before the change, but works after this PR, the new test case is [here](https://gist.github.com/hsqStephenZhang/cb46b90ffd929f1226aed5722ba08f33)).
