### PR TITLE
refactor: use new_search to create CancellationToken for search

### DIFF
--- a/cardinal/src-tauri/src/commands.rs
+++ b/cardinal/src-tauri/src/commands.rs
@@ -206,6 +206,7 @@ pub struct NodeInfo {
 }
 
 #[derive(Serialize, Default)]
+#[serde(rename_all = "camelCase")]
 pub struct SearchResponse {
     pub results: Vec<SlabIndex>,
     pub highlights: Vec<String>,
@@ -214,16 +215,7 @@ pub struct SearchResponse {
 
 impl SearchResponse {
     pub const OK: u8 = 0;
-    pub const ERROR: u8 = 1;
-    pub const CANCELLED: u8 = 2;
-
-    pub fn new_error() -> Self {
-        Self {
-            results: Default::default(),
-            highlights: Default::default(),
-            status_code: Self::ERROR,
-        }
-    }
+    pub const CANCELLED: u8 = 1;
 }
 
 #[derive(Serialize)]
@@ -293,14 +285,14 @@ pub async fn search(
         result_tx,
     }) {
         error!("Failed to send search request: {e:?}");
-        return Ok(SearchResponse::new_error());
+        return Err(format!("Failed to send search request: {e:?}"));
     }
 
     match result_rx.recv() {
         Ok(res) => res,
         Err(e) => {
             error!("Failed to receive search result: {e:?}");
-            return Ok(SearchResponse::new_error());
+            return Err(format!("Failed to receive search result: {e:?}"));
         }
     }
     .map(|SearchOutcome { nodes, highlights }| {

--- a/cardinal/src-tauri/src/commands.rs
+++ b/cardinal/src-tauri/src/commands.rs
@@ -207,8 +207,23 @@ pub struct NodeInfo {
 
 #[derive(Serialize, Default)]
 pub struct SearchResponse {
-    pub results: Option<Vec<SlabIndex>>,
+    pub results: Vec<SlabIndex>,
     pub highlights: Vec<String>,
+    pub status_code: u8,
+}
+
+impl SearchResponse {
+    pub const OK: u8 = 0;
+    pub const ERROR: u8 = 1;
+    pub const CANCELLED: u8 = 2;
+
+    pub fn new_error() -> Self {
+        Self {
+            results: Default::default(),
+            highlights: Default::default(),
+            status_code: Self::ERROR,
+        }
+    }
 }
 
 #[derive(Serialize)]
@@ -278,28 +293,29 @@ pub async fn search(
         result_tx,
     }) {
         error!("Failed to send search request: {e:?}");
-        return Ok(SearchResponse::default());
+        return Ok(SearchResponse::new_error());
     }
 
     match result_rx.recv() {
         Ok(res) => res,
         Err(e) => {
             error!("Failed to receive search result: {e:?}");
-            return Ok(SearchResponse::default());
+            return Ok(SearchResponse::new_error());
         }
     }
     .map(|SearchOutcome { nodes, highlights }| {
-        let results = match nodes {
-            Some(list) => Some(list),
+        let (status_code, results) = match nodes {
+            Some(list) => (SearchResponse::OK, list),
             None => {
                 let version = cancellation_token.version();
                 info!("Search {version} was cancelled");
-                None
+                (SearchResponse::CANCELLED, vec![])
             }
         };
         SearchResponse {
             results,
             highlights,
+            status_code,
         }
     })
     .map_err(|e| format!("Failed to process search result: {e:?}"))

--- a/cardinal/src-tauri/src/commands.rs
+++ b/cardinal/src-tauri/src/commands.rs
@@ -207,7 +207,7 @@ pub struct NodeInfo {
 
 #[derive(Serialize, Default)]
 pub struct SearchResponse {
-    pub results: Vec<SlabIndex>,
+    pub results: Option<Vec<SlabIndex>>,
     pub highlights: Vec<String>,
 }
 
@@ -264,13 +264,12 @@ pub async fn toggle_quicklook(app_handle: AppHandle, items: Vec<QuickLookItemInp
 pub async fn search(
     query: String,
     options: Option<SearchOptionsPayload>,
-    version: u64,
     state: State<'_, SearchState>,
 ) -> Result<SearchResponse, String> {
     search_activity::note_search_activity();
 
     let options = options.unwrap_or_default();
-    let cancellation_token = CancellationToken::new(version);
+    let cancellation_token = CancellationToken::new_search();
     let (result_tx, result_rx) = bounded(1);
     if let Err(e) = state.search_tx.send(SearchJob {
         query,
@@ -291,10 +290,11 @@ pub async fn search(
     }
     .map(|SearchOutcome { nodes, highlights }| {
         let results = match nodes {
-            Some(list) => list,
+            Some(list) => Some(list),
             None => {
+                let version = cancellation_token.version();
                 info!("Search {version} was cancelled");
-                Vec::new()
+                None
             }
         };
         SearchResponse {

--- a/cardinal/src/hooks/__tests__/useFileSearch.test.ts
+++ b/cardinal/src/hooks/__tests__/useFileSearch.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it, vi, afterEach } from 'vitest';
 import { invoke } from '@tauri-apps/api/core';
 import type { SlabIndex } from '../../types/slab';
 import { useFileSearch } from '../useFileSearch';
+import { SearchStatusCode } from '../../types/ipc';
 
 vi.mock('@tauri-apps/api/core', () => ({
   invoke: vi.fn(),
@@ -23,7 +24,11 @@ describe('useFileSearch', () => {
         return Promise.resolve('Ready');
       }
       if (command === 'search') {
-        return Promise.resolve({ results: backendResults, highlights: [] });
+        return Promise.resolve({
+          results: backendResults,
+          highlights: [],
+          status_code: SearchStatusCode.OK,
+        });
       }
       return Promise.resolve(null);
     });
@@ -34,5 +39,51 @@ describe('useFileSearch', () => {
 
     expect(result.current.state.results).toBe(backendResults);
     expect(result.current.state.resultCount).toBe(backendResults.length);
+  });
+
+  it('ignores results when backend returns null (cancelled)', async () => {
+    const initialResults = [1, 2, 3] as SlabIndex[];
+
+    mockedInvoke.mockImplementation((command: string) => {
+      if (command === 'get_app_status') {
+        return Promise.resolve('Ready');
+      }
+      if (command === 'search') {
+        // First call (initial search) returns results
+        return Promise.resolve({
+          results: initialResults,
+          highlights: [],
+          status_code: SearchStatusCode.OK,
+        });
+      }
+      return Promise.resolve(null);
+    });
+
+    const { result } = renderHook(() => useFileSearch());
+
+    // Wait for initial search to complete
+    await waitFor(() => expect(result.current.state.initialFetchCompleted).toBe(true));
+    expect(result.current.state.results).toBe(initialResults);
+
+    // Mock search to return null for the next call
+    mockedInvoke.mockImplementation((command: string) => {
+      if (command === 'search') {
+        return Promise.resolve({
+          results: [],
+          highlights: [],
+          status_code: SearchStatusCode.CANCELLED,
+        });
+      }
+      return Promise.resolve('Ready');
+    });
+
+    // Trigger a new search
+    result.current.queueSearch('new query', { immediate: true });
+
+    // The results should still be the initial results, not updated or cleared
+    // We wait a bit to ensure it had time to process if it were going to
+    await new Promise((resolve) => setTimeout(resolve, 50));
+    expect(result.current.state.results).toBe(initialResults);
+    expect(result.current.state.currentQuery).toBe(''); // Query doesn't update on cancelled search
   });
 });

--- a/cardinal/src/hooks/__tests__/useFileSearch.test.ts
+++ b/cardinal/src/hooks/__tests__/useFileSearch.test.ts
@@ -27,7 +27,7 @@ describe('useFileSearch', () => {
         return Promise.resolve({
           results: backendResults,
           highlights: [],
-          status_code: SearchStatusCode.OK,
+          statusCode: SearchStatusCode.OK,
         });
       }
       return Promise.resolve(null);
@@ -41,7 +41,7 @@ describe('useFileSearch', () => {
     expect(result.current.state.resultCount).toBe(backendResults.length);
   });
 
-  it('ignores results when backend returns null (cancelled)', async () => {
+  it('ignores results when backend returns CANCELLED status', async () => {
     const initialResults = [1, 2, 3] as SlabIndex[];
 
     mockedInvoke.mockImplementation((command: string) => {
@@ -53,7 +53,7 @@ describe('useFileSearch', () => {
         return Promise.resolve({
           results: initialResults,
           highlights: [],
-          status_code: SearchStatusCode.OK,
+          statusCode: SearchStatusCode.OK,
         });
       }
       return Promise.resolve(null);
@@ -65,13 +65,13 @@ describe('useFileSearch', () => {
     await waitFor(() => expect(result.current.state.initialFetchCompleted).toBe(true));
     expect(result.current.state.results).toBe(initialResults);
 
-    // Mock search to return null for the next call
+    // Mock search to return CANCELLED status for the next call
     mockedInvoke.mockImplementation((command: string) => {
       if (command === 'search') {
         return Promise.resolve({
           results: [],
           highlights: [],
-          status_code: SearchStatusCode.CANCELLED,
+          statusCode: SearchStatusCode.CANCELLED,
         });
       }
       return Promise.resolve('Ready');

--- a/cardinal/src/hooks/useFileSearch.ts
+++ b/cardinal/src/hooks/useFileSearch.ts
@@ -163,6 +163,9 @@ type UseFileSearchResult = {
 export function useFileSearch(): UseFileSearchResult {
   const [state, dispatch] = useReducer(reducer, initialSearchState);
   const latestSearchRef = useRef<SearchParams>(initialSearchParams);
+  // `search-cancellation` maintains an atomic counter
+  // and will auto-increment for each search request
+  // so this only serves as a defence-in-depth
   const searchVersionRef = useRef(0);
   const hasInitialSearchRunRef = useRef(false);
   const debounceTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
@@ -243,7 +246,7 @@ export function useFileSearch(): UseFileSearchResult {
       });
 
       if (
-        rawResults.status_code === SearchStatusCode.CANCELLED ||
+        rawResults.statusCode === SearchStatusCode.CANCELLED ||
         searchVersionRef.current !== requestVersion
       ) {
         return;

--- a/cardinal/src/hooks/useFileSearch.ts
+++ b/cardinal/src/hooks/useFileSearch.ts
@@ -210,6 +210,9 @@ export function useFileSearch(): UseFileSearchResult {
   const handleSearch = useCallback(async (overrides: Partial<SearchParams> = {}) => {
     const nextSearch = { ...latestSearchRef.current, ...overrides };
     latestSearchRef.current = nextSearch;
+    // the backend already has search version cancellation
+    // but we keep the check at frontend to make sure that
+    // the UI always reflects the latest request
     const requestVersion = searchVersionRef.current + 1;
     searchVersionRef.current = requestVersion;
 
@@ -233,17 +236,16 @@ export function useFileSearch(): UseFileSearchResult {
         options: {
           caseInsensitive: !caseSensitive,
         },
-        version: requestVersion,
       });
 
-      const searchResults = rawResults?.results as SlabIndex[];
-      const highlightTerms = Array.isArray(rawResults?.highlights)
-        ? rawResults.highlights.filter((term): term is string => typeof term === 'string')
-        : [];
-
-      if (searchVersionRef.current !== requestVersion) {
+      if (rawResults.results === null || searchVersionRef.current !== requestVersion) {
         return;
       }
+
+      const searchResults = rawResults.results as SlabIndex[];
+      const highlightTerms = Array.isArray(rawResults.highlights)
+        ? rawResults.highlights.filter((term): term is string => typeof term === 'string')
+        : [];
 
       cancelTimer(loadingDelayTimerRef);
 

--- a/cardinal/src/hooks/useFileSearch.ts
+++ b/cardinal/src/hooks/useFileSearch.ts
@@ -2,7 +2,11 @@ import { useReducer, useRef, useCallback, useEffect } from 'react';
 import type { MutableRefObject } from 'react';
 import { invoke } from '@tauri-apps/api/core';
 import { SEARCH_DEBOUNCE_MS } from '../constants';
-import type { AppLifecycleStatus, SearchResponsePayload } from '../types/ipc';
+import {
+  SearchStatusCode,
+  type AppLifecycleStatus,
+  type SearchResponsePayload,
+} from '../types/ipc';
 import type { SlabIndex } from '../types/slab';
 
 type SearchError = string | Error | null;
@@ -238,7 +242,10 @@ export function useFileSearch(): UseFileSearchResult {
         },
       });
 
-      if (rawResults.results === null || searchVersionRef.current !== requestVersion) {
+      if (
+        rawResults.status_code === SearchStatusCode.CANCELLED ||
+        searchVersionRef.current !== requestVersion
+      ) {
         return;
       }
 

--- a/cardinal/src/types/ipc.ts
+++ b/cardinal/src/types/ipc.ts
@@ -27,12 +27,11 @@ export type AppLifecycleStatus = 'Initializing' | 'Updating' | 'Ready';
 
 export enum SearchStatusCode {
   OK = 0,
-  ERROR = 1,
-  CANCELLED = 2,
+  CANCELLED = 1,
 }
 
 export type SearchResponsePayload = {
   results: number[];
   highlights?: string[];
-  status_code: SearchStatusCode;
+  statusCode: SearchStatusCode;
 };

--- a/cardinal/src/types/ipc.ts
+++ b/cardinal/src/types/ipc.ts
@@ -25,8 +25,14 @@ export type RecentEventPayload = {
 
 export type AppLifecycleStatus = 'Initializing' | 'Updating' | 'Ready';
 
+export enum SearchStatusCode {
+  OK = 0,
+  ERROR = 1,
+  CANCELLED = 2,
+}
+
 export type SearchResponsePayload = {
-  // null means search is cancelled
-  results: number[] | null;
+  results: number[];
   highlights?: string[];
+  status_code: SearchStatusCode;
 };

--- a/cardinal/src/types/ipc.ts
+++ b/cardinal/src/types/ipc.ts
@@ -26,6 +26,7 @@ export type RecentEventPayload = {
 export type AppLifecycleStatus = 'Initializing' | 'Updating' | 'Ready';
 
 export type SearchResponsePayload = {
-  results: number[];
+  // null means search is cancelled
+  results: number[] | null;
   highlights?: string[];
 };

--- a/doc/inner/search-cancellation.md
+++ b/doc/inner/search-cancellation.md
@@ -15,7 +15,7 @@ Search and scan cancellation are intentionally separate so a new rescan does not
 - the version captured at creation time
 
 Constructors:
-- `CancellationToken::new(version)` -> marks that search version as current
+- `CancellationToken::new_search()` -> increments and captures the search version
 - `CancellationToken::new_scan()` -> increments and captures the scan version
 - `CancellationToken::noop()` -> token backed by a private static atomic that never changes
 

--- a/doc/inner/ui-dataflow.md
+++ b/doc/inner/ui-dataflow.md
@@ -7,16 +7,15 @@ This chapter maps the React-side state graph to the Tauri command/event layer.
 SearchBar / keyboard submit
   -> useFilesTabState.queueSearch(...)
   -> useFileSearch.handleSearch(...)
-  -> invoke('search', { query, options, version })
-  -> SearchResponse { results, highlights }
+  -> invoke('search', { query, options })
+  -> SearchResponse { results, highlights, statusCode }
   -> useRemoteSort(...)
   -> <VirtualList results={displayedResults} ... />
 ```
 
-- `useFileSearch` owns the authoritative search state: raw `results`, `resultsVersion`, highlight terms, status counters, lifecycle state, loading UI, timing, and error state.
-- Each request increments `searchVersionRef` and passes that number as `version`.
-- The backend turns `version` into `CancellationToken::new(version)`.
-- React still discards stale responses locally if their request id is no longer current.
+- `useFileSearch` owns the authoritative search state: raw `results`, highlight terms, status counters, lifecycle state, loading UI, timing, and error state.
+- The backend owns the search version: each `invoke('search', ...)` call increments `ACTIVE_SEARCH_VERSION` via `CancellationToken::new_search()`, automatically cancelling any in-flight search. Cancelled searches return `statusCode: CANCELLED`; transport/processing failures return as `Err` (caught by the frontend `catch` path).
+- The frontend also tracks a local `searchVersionRef` as defence-in-depth: if a response arrives after a newer request was already fired, it is discarded regardless of `statusCode`.
 - Loading UI is immediate for the first search and delayed by 150 ms for later searches.
 
 ## Result projection and sorting
@@ -85,4 +84,4 @@ VirtualList
 ## Practical rule of thumb
 - Commands are used for request/response work (`search`, `get_nodes_info`, `get_sorted_view`).
 - Tauri events are used for push work (`status_bar_update`, `fs_events_batch`, `icon_update`, `quick_launch`).
-- Version tokens exist at both the backend and React layers because either side can observe stale work independently.
+- Cancellation is two-layered: the backend's `ACTIVE_SEARCH_VERSION` atomic is the primary mechanism (signals via `statusCode: CANCELLED`); the frontend's `searchVersionRef` is a secondary guard for responses that arrive after a newer request was issued but before the backend's cancellation is reflected.

--- a/namepool/src/lib.rs
+++ b/namepool/src/lib.rs
@@ -172,9 +172,9 @@ mod tests {
         pool.push("alpha");
         pool.push("beta");
 
-        let token = CancellationToken::new(1);
+        let token = CancellationToken::new_search();
         // Move global active version forward so the token becomes cancelled.
-        let _ = CancellationToken::new(2);
+        let _ = CancellationToken::new_search();
 
         assert!(pool.search_substr("a", token).is_none());
     }
@@ -185,8 +185,8 @@ mod tests {
         for idx in 0..5 {
             pool.push(&format!("item{idx}"));
         }
-        let token = CancellationToken::new(10);
-        let _ = CancellationToken::new(11);
+        let token = CancellationToken::new_search();
+        let _ = CancellationToken::new_search();
         let regex = Regex::new("item\\d").unwrap();
 
         assert!(pool.search_regex(&regex, token).is_none());

--- a/namepool/tests/fuzz_large.rs
+++ b/namepool/tests/fuzz_large.rs
@@ -178,8 +178,8 @@ fn regex_search_varied_patterns() {
 #[test]
 fn cancellation_simulation() {
     let pool = build_pool();
-    let token = CancellationToken::new(7777);
-    let _ = CancellationToken::new(7778); // cancel previous
+    let token = CancellationToken::new_search();
+    let _ = CancellationToken::new_search(); // cancel previous
     // All searches should return None due to cancellation.
     assert!(pool.search_substr("alpha", token).is_none());
     assert!(pool.search_prefix("alpha", token).is_none());

--- a/search-cache/src/cache.rs
+++ b/search-cache/src/cache.rs
@@ -1732,8 +1732,8 @@ mod tests {
         fs::File::create(dir.join("bar.txt")).unwrap();
 
         let mut cache = SearchCache::walk_fs(dir);
-        let token = CancellationToken::new(10);
-        let _ = CancellationToken::new(11); // cancel previous token
+        let token = CancellationToken::new_search();
+        let _ = CancellationToken::new_search(); // cancel previous token
 
         let result = cache.search_with_options(
             "bar !foo",
@@ -1976,8 +1976,8 @@ mod tests {
         fs::File::create(temp_dir.path().join("alpha.txt")).unwrap();
         let cache = SearchCache::walk_fs(temp_dir.path());
 
-        let token = CancellationToken::new(1000);
-        let _ = CancellationToken::new(1001);
+        let token = CancellationToken::new_search();
+        let _ = CancellationToken::new_search();
 
         assert!(cache.search_empty(token).is_none());
     }
@@ -1988,8 +1988,8 @@ mod tests {
         fs::File::create(temp_dir.path().join("file_a.txt")).unwrap();
         let mut cache = SearchCache::walk_fs(temp_dir.path());
 
-        let token = CancellationToken::new(2000);
-        let _ = CancellationToken::new(2001);
+        let token = CancellationToken::new_search();
+        let _ = CancellationToken::new_search();
 
         let result = cache.search_with_options(
             "file_a",
@@ -2110,8 +2110,8 @@ mod tests {
         fs::File::create(temp_dir.path().join("item.txt")).unwrap();
         let mut cache = SearchCache::walk_fs(temp_dir.path());
 
-        let token = CancellationToken::new(3000);
-        let _ = CancellationToken::new(3001);
+        let token = CancellationToken::new_search();
+        let _ = CancellationToken::new_search();
 
         let result = cache.query_files("item.txt", token);
         assert!(matches!(result, Ok(None)));

--- a/search-cache/src/tests/date_volume.rs
+++ b/search-cache/src/tests/date_volume.rs
@@ -486,7 +486,7 @@ fn segment_10_stress_queries() {
     let _ = cache.search("dm:pastmonth").unwrap();
     let _ = cache.search("dm:thisyear").unwrap();
     // ensure no cancellation
-    let token = CancellationToken::new(9999); // never cancelled
+    let token = CancellationToken::new_search(); // never cancelled
     let outcome = cache
         .search_with_options(
             "dm:2024-01-01-2024-03-01",

--- a/search-cache/src/tests/traversal.rs
+++ b/search-cache/src/tests/traversal.rs
@@ -113,8 +113,8 @@ fn test_all_subnodes_cancellation() {
     let root_idx = cache.file_nodes.root();
 
     // Create a cancelled token by creating a newer version
-    let token = CancellationToken::new(1);
-    let _newer_token = CancellationToken::new(2); // This cancels the first token
+    let token = CancellationToken::new_search();
+    let _newer_token = CancellationToken::new_search(); // This cancels the first token
 
     // Should return None when cancelled
     let result = cache.all_subnodes(root_idx, token);

--- a/search-cache/tests/boundary_limits_tests.rs
+++ b/search-cache/tests/boundary_limits_tests.rs
@@ -422,8 +422,8 @@ fn test_cancel_large_search_operation() {
     let mut cache = SearchCache::walk_fs(&root_path);
 
     // Create cancellation token and cancel it
-    let token_v1 = CancellationToken::new(1);
-    let _token_v2 = CancellationToken::new(2); // This cancels v1
+    let token_v1 = CancellationToken::new_search();
+    let _token_v2 = CancellationToken::new_search(); // This cancels v1
 
     // Large search should be cancelled
     let result = cache.query_files("file_", token_v1);

--- a/search-cache/tests/content_filter_comprehensive.rs
+++ b/search-cache/tests/content_filter_comprehensive.rs
@@ -587,8 +587,8 @@ fn content_filter_respects_cancellation() {
     let mut cache = SearchCache::walk_fs(dir);
 
     // Create a cancelled token
-    let token = CancellationToken::new(999);
-    let _ = CancellationToken::new(1000); // This cancels token 999
+    let token = CancellationToken::new_search();
+    let _ = CancellationToken::new_search(); // This cancels token 999
 
     let result = cache.search_with_options(
         "content:needle",

--- a/search-cache/tests/edge_cases_comprehensive.rs
+++ b/search-cache/tests/edge_cases_comprehensive.rs
@@ -56,10 +56,10 @@ fn test_cancellation_during_search() {
     let (mut cache, _root) = build_test_cache(&file_refs);
 
     // Create a cancellation token with version 1
-    let token_v1 = CancellationToken::new(1);
+    let token_v1 = CancellationToken::new_search();
 
     // Create a new version to cancel the old one
-    let _token_v2 = CancellationToken::new(2);
+    let _token_v2 = CancellationToken::new_search();
 
     // Search should return None due to cancellation
     let result = cache.query_files("file", token_v1);
@@ -90,8 +90,8 @@ fn test_cancellation_with_stop_flag() {
 
     // Set stop flag during search, then create new token to cancel previous
     stop.store(true, Ordering::SeqCst);
-    let token_v1 = CancellationToken::new(1);
-    let _token_v2 = CancellationToken::new(2);
+    let token_v1 = CancellationToken::new_search();
+    let _token_v2 = CancellationToken::new_search();
 
     let result = cache.query_files("test", token_v1);
     assert!(result.is_ok());

--- a/search-cache/tests/query_matrix_big.rs
+++ b/search-cache/tests/query_matrix_big.rs
@@ -185,8 +185,8 @@ fn case_insensitive_option_matrix() {
 #[test]
 fn cancellation_large_iteration() {
     let mut cache = build_cache();
-    let token = CancellationToken::new(9999);
-    let _later = CancellationToken::new(10000); // cancel token
+    let token = CancellationToken::new_search();
+    let _later = CancellationToken::new_search(); // cancel token
     let result = cache
         .search_with_options("src lib tests", SearchOptions::default(), token)
         .unwrap();

--- a/search-cancel/src/lib.rs
+++ b/search-cancel/src/lib.rs
@@ -179,16 +179,4 @@ mod tests {
         );
     }
 
-    #[test]
-    fn search_token_cancelled_after_new_search_version2() {
-        let _guard = lock_versions();
-        reset_versions();
-
-        let search_v1 = CancellationToken::new_search();
-        assert!(search_v1.is_cancelled().is_some());
-
-        let search_v2 = CancellationToken::new_search();
-        assert!(search_v2.is_cancelled().is_some());
-        assert!(search_v1.is_cancelled().is_none()); // search_v1 is now cancelled
-    }
 }

--- a/search-cancel/src/lib.rs
+++ b/search-cancel/src/lib.rs
@@ -32,6 +32,17 @@ impl CancellationToken {
         }
     }
 
+    /// create a token for search, different with `CancellationToken::new`
+    /// it uses global version's current version number
+    /// user don't need to specify a version number
+    pub fn new_search() -> Self {
+        let version = self::ACTIVE_SEARCH_VERSION.fetch_add(1, Ordering::SeqCst) + 1;
+        Self {
+            version,
+            active_version: &ACTIVE_SEARCH_VERSION,
+        }
+    }
+
     pub fn new_scan() -> Self {
         let version = self::ACTIVE_SCAN_VERSION.fetch_add(1, Ordering::SeqCst) + 1;
         Self {
@@ -54,6 +65,10 @@ impl CancellationToken {
         } else {
             Some(())
         }
+    }
+
+    pub fn version(&self) -> u64 {
+        self.version
     }
 }
 

--- a/search-cancel/src/lib.rs
+++ b/search-cancel/src/lib.rs
@@ -24,7 +24,8 @@ impl CancellationToken {
         }
     }
 
-    /// Creates a token for a search, unlike `CancellationToken::new`.
+    /// Creates a token for a search
+    ///
     /// It increments the global search version and returns a token for
     /// that new version, so the caller does not need to specify one.
     pub fn new_search() -> Self {

--- a/search-cancel/src/lib.rs
+++ b/search-cancel/src/lib.rs
@@ -24,14 +24,6 @@ impl CancellationToken {
         }
     }
 
-    pub fn new(version: u64) -> Self {
-        ACTIVE_SEARCH_VERSION.store(version, Ordering::SeqCst);
-        Self {
-            version,
-            active_version: &ACTIVE_SEARCH_VERSION,
-        }
-    }
-
     /// Creates a token for a search, unlike `CancellationToken::new`.
     /// It increments the global search version and returns a token for
     /// that new version, so the caller does not need to specify one.
@@ -127,14 +119,14 @@ mod tests {
     fn cancelled_after_version_change() {
         let _guard = lock_versions();
         reset_versions();
-        let token_v1 = CancellationToken::new(1);
+        let token_v1 = CancellationToken::new_search();
         assert!(
             token_v1.is_cancelled().is_some(),
             "initial version should be active"
         );
 
         // Bump the active version, cancelling the older token.
-        let _token_v2 = CancellationToken::new(2);
+        let _token_v2 = CancellationToken::new_search();
         assert!(token_v1.is_cancelled().is_none());
     }
 
@@ -165,14 +157,14 @@ mod tests {
         let _guard = lock_versions();
         reset_versions();
 
-        let search_v1 = CancellationToken::new(1);
+        let search_v1 = CancellationToken::new_search();
         let _scan_v1 = CancellationToken::new_scan();
         assert!(
             search_v1.is_cancelled().is_some(),
             "scan token updates should not affect search version"
         );
 
-        let _search_v2 = CancellationToken::new(2);
+        let _search_v2 = CancellationToken::new_search();
         assert!(
             search_v1.is_cancelled().is_none(),
             "search token should still be governed by search version updates"

--- a/search-cancel/src/lib.rs
+++ b/search-cancel/src/lib.rs
@@ -32,9 +32,9 @@ impl CancellationToken {
         }
     }
 
-    /// create a token for search, different with `CancellationToken::new`
-    /// it uses global version's current version number
-    /// user don't need to specify a version number
+    /// Creates a token for a search, unlike `CancellationToken::new`.
+    /// It increments the global search version and returns a token for
+    /// that new version, so the caller does not need to specify one.
     pub fn new_search() -> Self {
         let version = self::ACTIVE_SEARCH_VERSION.fetch_add(1, Ordering::SeqCst) + 1;
         Self {
@@ -102,6 +102,28 @@ mod tests {
     }
 
     #[test]
+    fn search_token_cancelled_after_new_search_version() {
+        let _guard = lock_versions();
+        reset_versions();
+
+        let search_v1 = CancellationToken::new_search();
+        assert!(
+            search_v1.is_cancelled().is_some(),
+            "latest search token should start active"
+        );
+
+        let search_v2 = CancellationToken::new_search();
+        assert!(
+            search_v2.is_cancelled().is_some(),
+            "new search token should be active"
+        );
+        assert!(
+            search_v1.is_cancelled().is_none(),
+            "older search token should be cancelled by newer search"
+        );
+    }
+
+    #[test]
     fn cancelled_after_version_change() {
         let _guard = lock_versions();
         reset_versions();
@@ -155,5 +177,18 @@ mod tests {
             search_v1.is_cancelled().is_none(),
             "search token should still be governed by search version updates"
         );
+    }
+
+    #[test]
+    fn search_token_cancelled_after_new_search_version2() {
+        let _guard = lock_versions();
+        reset_versions();
+
+        let search_v1 = CancellationToken::new_search();
+        assert!(search_v1.is_cancelled().is_some());
+
+        let search_v2 = CancellationToken::new_search();
+        assert!(search_v2.is_cancelled().is_some());
+        assert!(search_v1.is_cancelled().is_none()); // search_v1 is now cancelled
     }
 }

--- a/search-cancel/src/lib.rs
+++ b/search-cancel/src/lib.rs
@@ -170,5 +170,4 @@ mod tests {
             "search token should still be governed by search version updates"
         );
     }
-
 }

--- a/search-cancel/tests/more.rs
+++ b/search-cancel/tests/more.rs
@@ -18,12 +18,12 @@ fn lock_and_reset_versions() -> MutexGuard<'static, ()> {
 fn multiple_tokens_cancelled_independently() {
     let _guard = lock_and_reset_versions();
 
-    let t1 = CancellationToken::new(1);
+    let t1 = CancellationToken::new_search();
     assert!(t1.is_cancelled().is_some());
-    let t2 = CancellationToken::new(2);
+    let t2 = CancellationToken::new_search();
     assert!(t1.is_cancelled().is_none());
     assert!(t2.is_cancelled().is_some());
-    let t3 = CancellationToken::new(3);
+    let t3 = CancellationToken::new_search();
     assert!(t2.is_cancelled().is_none());
     assert!(t3.is_cancelled().is_some());
 }
@@ -49,8 +49,8 @@ fn search_version_changes_do_not_cancel_scan_token() {
     let _guard = lock_and_reset_versions();
 
     let scan = CancellationToken::new_scan();
-    let _search_v1 = CancellationToken::new(1);
-    let _search_v2 = CancellationToken::new(2);
+    let _search_v1 = CancellationToken::new_search();
+    let _search_v2 = CancellationToken::new_search();
     assert!(
         scan.is_cancelled().is_some(),
         "scan token should not be affected by search version updates"
@@ -114,8 +114,8 @@ fn active_scan_token_survives_many_search_bumps() {
     let _guard = lock_and_reset_versions();
 
     let scan = CancellationToken::new_scan();
-    for v in 1..=10_u64 {
-        let _search = CancellationToken::new(v);
+    for _ in 1..=10_u64 {
+        let _search = CancellationToken::new_search();
     }
     assert!(
         scan.is_cancelled().is_some(),


### PR DESCRIPTION
## Fix 

fix #191 

## Goal 

let `search-cache` decide if the version is outdated since there is only a global counter. 

## Solution

1. update the `search-cancel` to provide a new api that `fetch_and_add(counter, 1)`
2. update the payload definition to make sure frontend is aware of the cancelation. 

## Test 

via observation that there is no anomaly