### PR TITLE
fix(a11y): add aria-label to search input

### DIFF
--- a/cardinal/src/App.tsx
+++ b/cardinal/src/App.tsx
@@ -358,6 +358,7 @@ function App() {
   const searchPlaceholder =
     activeTab === 'files' ? t('search.placeholder.files') : t('search.placeholder.events');
   const directorySearchPlaceholder = t('search.placeholder.directory');
+  const searchAriaLabel = t('search.aria.searchInput');
   const permissionSteps = [
     t('app.fullDiskAccess.steps.one'),
     t('app.fullDiskAccess.steps.two'),
@@ -374,6 +375,7 @@ function App() {
         <SearchBar
           inputRef={searchInputRef}
           placeholder={searchPlaceholder}
+          ariaLabel={searchAriaLabel}
           value={searchInputValue}
           onChange={onQueryChange}
           onKeyDown={onSearchInputKeyDown}

--- a/cardinal/src/components/SearchBar.tsx
+++ b/cardinal/src/components/SearchBar.tsx
@@ -8,6 +8,7 @@ const MACOS_FOLDER_ICON =
 type SearchBarProps = {
   inputRef: React.RefObject<HTMLInputElement>;
   placeholder: string;
+  ariaLabel: string;
   value: string;
   onChange: (event: ChangeEvent<HTMLInputElement>) => void;
   onKeyDown: (event: React.KeyboardEvent<HTMLInputElement>) => void;
@@ -37,6 +38,7 @@ const isCollapsedAtEnd = (input: HTMLInputElement): boolean => {
 export function SearchBar({
   inputRef,
   placeholder,
+  ariaLabel,
   value,
   onChange,
   onKeyDown,
@@ -164,6 +166,7 @@ export function SearchBar({
             onChange={onChange}
             onKeyDown={handleQueryKeyDown}
             placeholder={placeholder}
+            aria-label={ariaLabel}
             spellCheck={false}
             autoCorrect="off"
             autoComplete="off"

--- a/cardinal/src/components/__tests__/SearchBar.test.tsx
+++ b/cardinal/src/components/__tests__/SearchBar.test.tsx
@@ -8,6 +8,7 @@ const renderSearchBar = (overrides: Partial<ComponentProps<typeof SearchBar>> = 
   const props: ComponentProps<typeof SearchBar> = {
     inputRef: createRef<HTMLInputElement>(),
     placeholder: 'Search',
+    ariaLabel: 'Search input',
     value: '',
     onChange: vi.fn(),
     onKeyDown: vi.fn(),

--- a/cardinal/src/i18n/resources/ar-SA.json
+++ b/cardinal/src/i18n/resources/ar-SA.json
@@ -8,6 +8,9 @@
     "options": {
       "caseSensitive": "تفعيل/إيقاف حساسية حالة الأحرف",
       "directoryScope": "تبديل نطاق المجلد"
+    },
+    "aria": {
+      "searchInput": "إدخال البحث"
     }
   },
   "stateDisplay": {

--- a/cardinal/src/i18n/resources/de-DE.json
+++ b/cardinal/src/i18n/resources/de-DE.json
@@ -8,6 +8,9 @@
     "options": {
       "caseSensitive": "Groß-/Kleinschreibung beachten",
       "directoryScope": "Ordnerbereich umschalten"
+    },
+    "aria": {
+      "searchInput": "Sucheingabe"
     }
   },
   "stateDisplay": {

--- a/cardinal/src/i18n/resources/en-US.json
+++ b/cardinal/src/i18n/resources/en-US.json
@@ -8,6 +8,9 @@
     "options": {
       "caseSensitive": "Toggle case-sensitive matching",
       "directoryScope": "Toggle folder scope"
+    },
+    "aria": {
+      "searchInput": "Search input"
     }
   },
   "stateDisplay": {

--- a/cardinal/src/i18n/resources/es-ES.json
+++ b/cardinal/src/i18n/resources/es-ES.json
@@ -8,6 +8,9 @@
     "options": {
       "caseSensitive": "Activar coincidencia sensible a mayúsculas",
       "directoryScope": "Alternar ámbito de carpeta"
+    },
+    "aria": {
+      "searchInput": "Entrada de búsqueda"
     }
   },
   "stateDisplay": {

--- a/cardinal/src/i18n/resources/fr-FR.json
+++ b/cardinal/src/i18n/resources/fr-FR.json
@@ -8,6 +8,9 @@
     "options": {
       "caseSensitive": "Activer la correspondance sensible à la casse",
       "directoryScope": "Afficher la portée du dossier"
+    },
+    "aria": {
+      "searchInput": "Entrée de recherche"
     }
   },
   "stateDisplay": {

--- a/cardinal/src/i18n/resources/hi-IN.json
+++ b/cardinal/src/i18n/resources/hi-IN.json
@@ -8,6 +8,9 @@
     "options": {
       "caseSensitive": "केस-सेंसिटिव मिलान टॉगल करें",
       "directoryScope": "फ़ोल्डर स्कोप टॉगल करें"
+    },
+    "aria": {
+      "searchInput": "खोज इनपुट"
     }
   },
   "stateDisplay": {

--- a/cardinal/src/i18n/resources/it-IT.json
+++ b/cardinal/src/i18n/resources/it-IT.json
@@ -8,6 +8,9 @@
     "options": {
       "caseSensitive": "Attiva/disattiva distinzione tra maiuscole e minuscole",
       "directoryScope": "Mostra ambito cartella"
+    },
+    "aria": {
+      "searchInput": "Input di ricerca"
     }
   },
   "stateDisplay": {

--- a/cardinal/src/i18n/resources/ja-JP.json
+++ b/cardinal/src/i18n/resources/ja-JP.json
@@ -8,6 +8,9 @@
     "options": {
       "caseSensitive": "大文字と小文字を区別する",
       "directoryScope": "フォルダ範囲を切り替え"
+    },
+    "aria": {
+      "searchInput": "検索入力"
     }
   },
   "stateDisplay": {

--- a/cardinal/src/i18n/resources/ko-KR.json
+++ b/cardinal/src/i18n/resources/ko-KR.json
@@ -8,6 +8,9 @@
     "options": {
       "caseSensitive": "대소문자 구분 검색 전환",
       "directoryScope": "폴더 범위 전환"
+    },
+    "aria": {
+      "searchInput": "검색 입력"
     }
   },
   "stateDisplay": {

--- a/cardinal/src/i18n/resources/pt-BR.json
+++ b/cardinal/src/i18n/resources/pt-BR.json
@@ -8,6 +8,9 @@
     "options": {
       "caseSensitive": "Alternar correspondência sensível a maiúsculas",
       "directoryScope": "Alternar escopo de pasta"
+    },
+    "aria": {
+      "searchInput": "Entrada de pesquisa"
     }
   },
   "stateDisplay": {

--- a/cardinal/src/i18n/resources/ru-RU.json
+++ b/cardinal/src/i18n/resources/ru-RU.json
@@ -8,6 +8,9 @@
     "options": {
       "caseSensitive": "Включить учет регистра",
       "directoryScope": "Переключить область папок"
+    },
+    "aria": {
+      "searchInput": "Поле поиска"
     }
   },
   "stateDisplay": {

--- a/cardinal/src/i18n/resources/tr-TR.json
+++ b/cardinal/src/i18n/resources/tr-TR.json
@@ -8,6 +8,9 @@
     "options": {
       "caseSensitive": "Büyük/küçük harfe duyarlı eşleşmeyi değiştir",
       "directoryScope": "Klasör kapsamını değiştir"
+    },
+    "aria": {
+      "searchInput": "Arama girişi"
     }
   },
   "stateDisplay": {

--- a/cardinal/src/i18n/resources/uk-UA.json
+++ b/cardinal/src/i18n/resources/uk-UA.json
@@ -8,6 +8,9 @@
     "options": {
       "caseSensitive": "Перемкнути врахування регістру",
       "directoryScope": "Перемкнути область папок"
+    },
+    "aria": {
+      "searchInput": "Поле пошуку"
     }
   },
   "stateDisplay": {

--- a/cardinal/src/i18n/resources/zh-CN.json
+++ b/cardinal/src/i18n/resources/zh-CN.json
@@ -8,6 +8,9 @@
     "options": {
       "caseSensitive": "切换区分大小写匹配",
       "directoryScope": "切换文件夹范围"
+    },
+    "aria": {
+      "searchInput": "搜索输入"
     }
   },
   "stateDisplay": {

--- a/cardinal/src/i18n/resources/zh-TW.json
+++ b/cardinal/src/i18n/resources/zh-TW.json
@@ -8,6 +8,9 @@
     "options": {
       "caseSensitive": "切換區分大小寫比對",
       "directoryScope": "切換資料夾範圍"
+    },
+    "aria": {
+      "searchInput": "搜尋輸入"
     }
   },
   "stateDisplay": {


### PR DESCRIPTION
The search input had no accessible name, making it invisible to assistive technologies. Added `aria-label` with i18n key `search.aria.searchInput` threaded through App → SearchBar. Updated all 15 locale files.

Split out from #219 — this is an independently mergeable accessibility fix.